### PR TITLE
Found fix for react testing library not working with css and svg imports

### DIFF
--- a/empty-module.js
+++ b/empty-module.js
@@ -1,0 +1,1 @@
+module.exports = ''

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "underscore": "^1.13.1"
   },
   "jest": {
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "moduleNameMapper": {
+      "\\.(css|jpg|png|svg)$": "<rootDir>/empty-module.js"
+    }
   }
 }


### PR DESCRIPTION
This will allow you to run npm test without having to comment out css and image imports 